### PR TITLE
Fix typo in chunk README

### DIFF
--- a/chunk/README.md
+++ b/chunk/README.md
@@ -4,7 +4,7 @@ Split a IEnumerable<T> into chunks of IEnumerable<T> with a specified size.
 Chunk size = 50;
 
 - ChunkCore - .Net implementation with T[] Chunk()
-- ChunkLigh - use a special structure to manage an IEnumerable
+- ChunkLight - use a special structure to manage an IEnumerable
 - Chunk - simplest implementation with yield.
 
 ## Results


### PR DESCRIPTION
## Summary
- correct `ChunkLight` bullet typo in chunk README

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400fce996c8324bf6dd64a2b2d1232