### PR TITLE
Add concurrent test for LockFreeStringPool

### DIFF
--- a/string_pool/StringPoolTests/ConcurrentGetIdTests.cs
+++ b/string_pool/StringPoolTests/ConcurrentGetIdTests.cs
@@ -15,15 +15,14 @@ public class ConcurrentGetIdTests
         var ids = new int[threadCount];
         var threads = new Thread[threadCount];
 
+        var tasks = new Task[threadCount];
         for (var i = 0; i < threadCount; i++)
         {
             var index = i;
-            threads[i] = new Thread(() => ids[index] = pool.GetId(value));
-            threads[i].Start();
+            tasks[i] = Task.Run(() => ids[index] = pool.GetId(value));
         }
 
-        foreach (var t in threads)
-            t.Join();
+        Task.WhenAll(tasks).Wait();
 
         for (var i = 1; i < threadCount; i++)
             Assert.Equal(ids[0], ids[i]);

--- a/string_pool/StringPoolTests/ConcurrentGetIdTests.cs
+++ b/string_pool/StringPoolTests/ConcurrentGetIdTests.cs
@@ -1,0 +1,34 @@
+﻿using JetBrains.Annotations;
+using StringPoolBenchmark;
+
+namespace StringPoolTests;
+
+[UsedImplicitly]
+public class ConcurrentGetIdTests
+{
+    [Fact]
+    public void GetId_ShouldReturnSameId_WhenCalledFromMultipleThreads()
+    {
+        const int threadCount = 8;
+        const string value = "concurrent";
+        var pool = new LockFreeStringPool();
+        var ids = new int[threadCount];
+        var threads = new Thread[threadCount];
+
+        for (var i = 0; i < threadCount; i++)
+        {
+            var index = i;
+            threads[i] = new Thread(() => ids[index] = pool.GetId(value));
+            threads[i].Start();
+        }
+
+        foreach (var t in threads)
+            t.Join();
+
+        for (var i = 1; i < threadCount; i++)
+            Assert.Equal(ids[0], ids[i]);
+
+        Assert.True(pool.TryGetString(ids[0], out var retrieved));
+        Assert.Equal(value, retrieved);
+    }
+}


### PR DESCRIPTION
## Summary
- test concurrent GetId to ensure LockFreeStringPool returns consistent ids

## Testing
- `dotnet test string_pool/StringPoolTests/StringPoolTests.csproj -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684013bfc1908324a24f2907735ed891